### PR TITLE
replace xerrors with 1.13 standard errors package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//cmd:go_default_library",
         "//pkg/spanner:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,21 +3,24 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz"],
     sha256 = "313f2c7a23fecc33023563f082f381a32b9b7254f727a7dd2d6380ccc6dfe09b",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz"],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz"],
     sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz"],
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
 gazelle_dependencies()
 
 git_repository(
@@ -28,22 +31,25 @@ git_repository(
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
 
 load("//:bazel/deps.bzl", "wrench_deps")
+
 wrench_deps()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.9.0/rules_docker-v0.9.0.tar.gz"],
     sha256 = "e513c0ac6534810eb7a14bf025a0f159726753f97f74ab7863c650d26e01d677",
     strip_prefix = "rules_docker-0.9.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.9.0/rules_docker-v0.9.0.tar.gz"],
 )
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
+
 container_repositories()
 
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,20 +3,20 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "313f2c7a23fecc33023563f082f381a32b9b7254f727a7dd2d6380ccc6dfe09b",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz"],
+    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(go_version = "1.13")
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz"],
+    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -217,9 +217,3 @@ def wrench_deps():
         sum = "h1:uIfBkD8gLczr4XDgYpt/qJYds2YJwZRNw4zs7wSnNhk=",
         version = "v0.0.0-20190624190245-7f2218787638",
     )
-    go_repository(
-        name = "org_golang_x_xerrors",
-        importpath = "golang.org/x/xerrors",
-        sum = "h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=",
-        version = "v0.0.0-20190717185122-a985d3407aa7",
-    )

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//pkg/spanner:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mercari/wrench/pkg/spanner"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -146,8 +145,8 @@ func migrateVersion(c *cobra.Command, args []string) error {
 
 	v, _, err := client.GetSchemaMigrationVersion(ctx, migrationTableName)
 	if err != nil {
-		se := &spanner.Error{}
-		if xerrors.As(err, &se) && se.Code == spanner.ErrorCodeNoMigration {
+		var se *spanner.Error
+		if errors.As(err, &se) && se.Code == spanner.ErrorCodeNoMigration {
 			fmt.Println("No migrations.")
 			return nil
 		}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 var resetCmd = &cobra.Command{
@@ -24,7 +25,7 @@ func reset(c *cobra.Command, args []string) error {
 }
 
 func errorReset(c *cobra.Command, err error) error {
-	if ue := xerrors.Unwrap(err); ue != nil {
+	if ue := errors.Unwrap(err); ue != nil {
 		return &Error{
 			cmd: c,
 			err: ue,

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610
 	google.golang.org/grpc v1.22.0
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/api v0.7.0
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610
 	google.golang.org/grpc v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/mercari/wrench/cmd"
 	"github.com/mercari/wrench/pkg/spanner"
-	"golang.org/x/xerrors"
 )
 
 func main() {
@@ -25,8 +25,8 @@ func handleError(err error) {
 }
 
 func errorDetails(err error) string {
-	se := &spanner.Error{}
-	if xerrors.As(err, &se) {
+	var se *spanner.Error
+	if errors.As(err, &se) {
 		switch se.Code {
 		case spanner.ErrorCodeCreateClient:
 			return fmt.Sprintf("Failed to connect to Cloud Spanner, %s", se.Error())
@@ -37,12 +37,12 @@ func errorDetails(err error) string {
 		}
 	}
 
-	pe := &os.PathError{}
-	if xerrors.As(err, &pe) {
+	var pe *os.PathError
+	if errors.As(err, &pe) {
 		return fmt.Sprintf("Invalid file path, %s", pe.Error())
 	}
 
-	if err := xerrors.Unwrap(err); err != nil {
+	if err := errors.Unwrap(err); err != nil {
 		return fmt.Sprintf("%s", err.Error())
 	}
 

--- a/pkg/spanner/BUILD.bazel
+++ b/pkg/spanner/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "@org_golang_google_api//iterator:go_default_library",
         "@org_golang_google_api//option:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -8,7 +8,6 @@ import (
 
 	"cloud.google.com/go/spanner"
 	admin "cloud.google.com/go/spanner/admin/database/apiv1"
-	"golang.org/x/xerrors"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	databasepb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
@@ -208,8 +207,8 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 
 	version, dirty, err := c.GetSchemaMigrationVersion(ctx, tableName)
 	if err != nil {
-		se := &Error{}
-		if !xerrors.As(err, &se) || se.Code != ErrorCodeNoMigration {
+		var se *Error
+		if !errors.As(err, &se) || se.Code != ErrorCodeNoMigration {
 			return &Error{
 				Code: ErrorCodeExecuteMigrations,
 				err:  err,
@@ -332,7 +331,8 @@ func (c *Client) SetSchemaMigrationVersion(ctx context.Context, version uint, di
 				tableName,
 				[]string{"Version", "Dirty"},
 				[]interface{}{int64(version), dirty},
-			)}
+			),
+		}
 		return tx.BufferWrite(m)
 	})
 	if err != nil {

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -3,9 +3,8 @@ package spanner
 import (
 	"context"
 	"io/ioutil"
-	"testing"
-
 	"os"
+	"testing"
 
 	"cloud.google.com/go/spanner"
 	"google.golang.org/api/iterator"


### PR DESCRIPTION
## WHAT

<!--
Write the change being made with this pull request
-->

- replace xerrors with standard errors package.
    - Finally, Go 1.13 has been released 🎉 

### TODO

- [x] specify `go_version = 1.13` to `go_register_toolchains` in `WORKSPACE`.
    - https://github.com/bazelbuild/rules_go/pull/2211

## WHY

<!--
Write the motivation why you submit this pull request
-->

- Now Is/As/Unwrap are included in standard errors package.